### PR TITLE
ECDC-4544: Update the conan-qplot package to Qt6

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ variables:
   CONAN_USER: "ess-dmsc"
   CONAN_PKG_CHANNEL: "stable"
   PROJECT_NAME: "conan-qplot"
-  TARGET_CONTAINER_UPLOAD_REMOTE: "centos7-gcc11"
+  TARGET_CONTAINER_UPLOAD_REMOTE: "centos7-gcc11-qt6"
   CONAN_EXTERNAL_NAME: "ecdc-conan-external"
   CONAN_EXTERNAL_URL: "https://artifactory.esss.lu.se/artifactory/api/conan/ecdc-conan-external"
   CONAN_RELEASE_NAME: "ecdc-conan-release"
@@ -38,13 +38,13 @@ container_build_node:
 
         setup_conan "$CONAN_EXTERNAL_NAME" "$CONAN_EXTERNAL_URL"
         setup_conan "$CONAN_RELEASE_NAME" "$CONAN_RELEASE_URL"
-        
+
         # Configurations for Conan package creation
         configurations=(
           "settings=(\"qplot:build_type=Release\") options=(\"qplot:shared=False\")"
           "settings=(\"qplot:build_type=Debug\") options=(\"qplot:shared=False\")"
         )
-        
+
         # Create a Conan Package for each configuration
         for config in "${configurations[@]}"; do
           eval "$config"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,7 @@ container_build_node:
         IMAGE: "registry.esss.lu.se/ecdc/ess-dmsc/docker-almalinux8-build-node:1.1.0"
         SHELL: "/usr/bin/scl enable gcc-toolset-12 -- /bin/bash -e -x"
       - CONTAINER: "ubuntu2204"
-        IMAGE: "registry.esss.lu.se/ecdc/ess-dmsc/build-nodes/ubuntu2204-qt6:1.0"
+        IMAGE: "registry.esss.lu.se/ecdc/ess-dmsc/build-nodes/ubuntu2204-qt6:1.1"
         SHELL: "bash -e -x"
   image: $IMAGE
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,7 @@ container_build_node:
         IMAGE: "registry.esss.lu.se/ecdc/ess-dmsc/docker-almalinux8-build-node:1.1.0"
         SHELL: "/usr/bin/scl enable gcc-toolset-12 -- /bin/bash -e -x"
       - CONTAINER: "ubuntu2204"
-        IMAGE: "registry.esss.lu.se/ecdc/ess-dmsc/docker-ubuntu2204-build-node:5.0.0"
+        IMAGE: "registry.esss.lu.se/ecdc/ess-dmsc/build-nodes/ubuntu2204-qt6:1.0"
         SHELL: "bash -e -x"
   image: $IMAGE
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ container_build_node:
   parallel:
     matrix:
       - CONTAINER: "centos7-gcc11"
-        IMAGE: "registry.esss.lu.se/ecdc/ess-dmsc/docker-centos7-build-node:12.3.0"
+        IMAGE: "registry.esss.lu.se/ecdc/ess-dmsc/build-nodes/centos7-qt6:1.0"
         SHELL: "/usr/bin/scl enable devtoolset-11 rh-python38 -- /bin/bash -e -x"
       - CONTAINER: "almalinux8-gcc12"
         IMAGE: "registry.esss.lu.se/ecdc/ess-dmsc/docker-almalinux8-build-node:1.1.0"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ conan_user = "ess-dmsc"
 conan_pkg_channel = "stable"
 
 container_build_nodes = [
-  'centos': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc11'),
+  'centos': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc11-qt6'),
   'ubuntu2204': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu2204')
 ]
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ conan_pkg_channel = "stable"
 
 container_build_nodes = [
   'centos':     ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc11-qt6'),
-  'ubuntu2204': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu2204')
+  'ubuntu2204': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu2204-qt6')
 ]
 
 package_builder = new ConanPackageBuilder(this, container_build_nodes, conan_pkg_channel)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,8 +8,8 @@ conan_user = "ess-dmsc"
 conan_pkg_channel = "stable"
 
 container_build_nodes = [
-  'centos': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc11-qt6'),
-  'ubuntu2204': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu2204')
+  'centos':     ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc11-qt6'),
+  'ubuntu2204': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu2204-qt6')
 ]
 
 package_builder = new ConanPackageBuilder(this, container_build_nodes, conan_pkg_channel)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,8 +8,8 @@ conan_user = "ess-dmsc"
 conan_pkg_channel = "stable"
 
 container_build_nodes = [
-  'centos'    : ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc11-qt6'),
-  'ubuntu2204': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu2204-qt6')
+  'centos'     : ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc11-qt6'),
+  'ubuntu2204' : ContainerBuildNode.getDefaultContainerBuildNode('ubuntu2204-qt6')
 ]
 
 package_builder = new ConanPackageBuilder(this, container_build_nodes, conan_pkg_channel)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ conan_user = "ess-dmsc"
 conan_pkg_channel = "stable"
 
 container_build_nodes = [
-  'centos' :     ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc11-qt6'),
+  'centos'     : ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc11-qt6'),
   'ubuntu2204' : ContainerBuildNode.getDefaultContainerBuildNode('ubuntu2204-qt6')
 ]
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,8 +8,8 @@ conan_user = "ess-dmsc"
 conan_pkg_channel = "stable"
 
 container_build_nodes = [
-  'centos':     ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc11-qt6'),
-  'ubuntu2204': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu2204-qt6')
+  'centos':     ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc11'),
+  'ubuntu2204': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu2204')
 ]
 
 package_builder = new ConanPackageBuilder(this, container_build_nodes, conan_pkg_channel)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ conan_user = "ess-dmsc"
 conan_pkg_channel = "stable"
 
 container_build_nodes = [
-  'centos':     ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc11'),
+  'centos':     ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc11-qt6'),
   'ubuntu2204': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu2204')
 ]
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ conan_user = "ess-dmsc"
 conan_pkg_channel = "stable"
 
 container_build_nodes = [
-  'centos':     ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc11-qt6'),
+  'centos'    : ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc11-qt6'),
   'ubuntu2204': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu2204-qt6')
 ]
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ conan_user = "ess-dmsc"
 conan_pkg_channel = "stable"
 
 container_build_nodes = [
-  'centos'     : ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc11-qt6'),
+  'centos' :     ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc11-qt6'),
   'ubuntu2204' : ContainerBuildNode.getDefaultContainerBuildNode('ubuntu2204-qt6')
 ]
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,7 @@ from conans.util import files
 
 class qplotConan(ConanFile):
     name = "qplot"
-    version = "6e192ab"
+    version = "4029c03"
     license = "https://github.com/ess-dmsc/qplot/blob/master/LICENSE"
     url = "https://github.com/ess-dmsc/conan-qplot"
     description = "Wrappers and convenience classes for scientific plotting with QtWidgets"

--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,7 @@ from conans.util import files
 
 class qplotConan(ConanFile):
     name = "qplot"
-    version = "4029c03"
+    version = "4029c0397121d8bd"
     license = "https://github.com/ess-dmsc/qplot/blob/master/LICENSE"
     url = "https://github.com/ess-dmsc/conan-qplot"
     description = "Wrappers and convenience classes for scientific plotting with QtWidgets"

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -4,17 +4,16 @@ cmake_minimum_required(VERSION 2.8.12)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(KEEP_RPATHS)
 
-#For Qt
-if(APPLE AND EXISTS /usr/local/opt/qt)
-  # Homebrew installs Qt5 (up to at least 5.9.1) in
-  # /usr/local/opt/qt, ensure it can be found by CMake since
-  # it is not in the default /usr/local prefix.
-  list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/qt")
+# Use the env variable QT6_DIR to add Qt's cmake directory to CMAKE_PREFIX_PATH
+if(NOT DEFINED ENV{QT6_DIR})
+  message(STATUS "The environment variable QT6_DIR has not been set. It should point to the root location of your Qt6 installation")
 endif()
+list(APPEND CMAKE_PREFIX_PATH "$ENV{QT6_DIR}/lib/cmake")
+
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
-find_package(Qt6 COMPONENTS Widgets PrintSupport REQUIRED)
 
+find_package(Qt6 COMPONENTS Widgets PrintSupport Core5Compat REQUIRED)
 find_package(qplot REQUIRED)
 
 add_executable(example example.cpp)
@@ -22,7 +21,9 @@ target_link_libraries(example
     ${CONAN_LIBS}
     QPlot
     Qt6::Widgets
-    Qt6::PrintSupport)
+    Qt6::PrintSupport
+    Qt6::Core5Compat
+    )
 
 # ------------------------------------------------------------------------------
 # CTest is a testing tool that can be used to test your project.

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -13,7 +13,7 @@ if(APPLE AND EXISTS /usr/local/opt/qt)
 endif()
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
-find_package(Qt5 COMPONENTS Widgets PrintSupport REQUIRED)
+find_package(Qt6 COMPONENTS Widgets PrintSupport REQUIRED)
 
 find_package(qplot REQUIRED)
 
@@ -21,8 +21,8 @@ add_executable(example example.cpp)
 target_link_libraries(example
     ${CONAN_LIBS}
     QPlot
-    Qt5::Widgets
-    Qt5::PrintSupport)
+    Qt6::Widgets
+    Qt6::PrintSupport)
 
 # ------------------------------------------------------------------------------
 # CTest is a testing tool that can be used to test your project.

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -9,6 +9,7 @@ if(NOT DEFINED ENV{QT6_DIR})
   message(STATUS "The environment variable QT6_DIR has not been set. It should point to the root location of your Qt6 installation")
 endif()
 list(APPEND CMAKE_PREFIX_PATH "$ENV{QT6_DIR}/lib/cmake")
+list(APPEND CMAKE_PREFIX_PATH "/usr/lib/x86_64-linux-gnu")
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(example
     Qt5::Widgets
     Qt5::PrintSupport)
 
+# ------------------------------------------------------------------------------
 # CTest is a testing tool that can be used to test your project.
 # enable_testing()
 # add_test(NAME example

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -9,7 +9,6 @@ if(NOT DEFINED ENV{QT6_DIR})
   message(STATUS "The environment variable QT6_DIR has not been set. It should point to the root location of your Qt6 installation")
 endif()
 list(APPEND CMAKE_PREFIX_PATH "$ENV{QT6_DIR}/lib/cmake")
-list(APPEND CMAKE_PREFIX_PATH "/usr/lib/x86_64-linux-gnu")
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -20,6 +20,7 @@ class qplotTestConan(ConanFile):
     def test(self):
         if not tools.cross_building(self.settings):
             os.chdir("bin")
+            self.run("objdump -s -j .note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6Core.so.6.2.4")
             self.run("ldd `which qmake6`")
             self.run("strip -v --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6*.so.?.?.?")
             self.run("ldd `which qmake6`")

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -23,6 +23,4 @@ class qplotTestConan(ConanFile):
             os.chdir("bin")
 #            self.run("objdump -s -j .note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6Core.so.6.2.4")
             self.run("ldd `which qmake6`")
-            self.run("strip -v --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6*.so.?.?.?")
-            self.run("ldd `which qmake6`")
             self.run(".%sexample -platform offscreen" % os.sep)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -18,6 +18,7 @@ class qplotTestConan(ConanFile):
         self.copy("*.a", dst="bin", src='lib')
 
     def test(self):
+        # Test
         if not tools.cross_building(self.settings):
             os.chdir("bin")
 #            self.run("objdump -s -j .note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6Core.so.6.2.4")

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -18,10 +18,11 @@ class qplotTestConan(ConanFile):
         self.copy("*.a", dst="bin", src='lib')
 
     def test(self):
-        # Test not
+        # Test
         if not tools.cross_building(self.settings):
             os.chdir("bin")
 #            self.run("objdump -s -j .note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6Core.so.6.2.4")
-            self.run("ls /usr/lib/x86_64-linux-gnu/libQt6Core.so.6.2.4")
+            self.run("ldd `which qmake6`")
+            self.run("strip -v --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6*.so.?.?.?")
             self.run("ldd `which qmake6`")
             self.run(".%sexample -platform offscreen" % os.sep)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -20,4 +20,5 @@ class qplotTestConan(ConanFile):
     def test(self):
         if not tools.cross_building(self.settings):
             os.chdir("bin")
+            self.run("ldd /usr/lib/x86_64-linux-gnu/libQt6Gui.so")
             self.run(".%sexample -platform offscreen" % os.sep)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -21,6 +21,6 @@ class qplotTestConan(ConanFile):
         if not tools.cross_building(self.settings):
             os.chdir("bin")
             self.run("ldd `which qmake6`")
-            # self.run("strip -v --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6*.so.?.?.?")
-            # self.run("ldd `which qmake6`")
+            self.run("strip -v --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6*.so.?.?.?")
+            self.run("ldd `which qmake6`")
             self.run(".%sexample -platform offscreen" % os.sep)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -18,7 +18,7 @@ class qplotTestConan(ConanFile):
         self.copy("*.a", dst="bin", src='lib')
 
     def test(self):
-        # Test
+        # Test not
         if not tools.cross_building(self.settings):
             os.chdir("bin")
 #            self.run("objdump -s -j .note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6Core.so.6.2.4")

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -20,5 +20,5 @@ class qplotTestConan(ConanFile):
     def test(self):
         if not tools.cross_building(self.settings):
             os.chdir("bin")
-            self.run("qmake -v")
+            self.run("qmake6 -v")
             self.run(".%sexample -platform offscreen" % os.sep, ignore_errors=True)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -21,8 +21,4 @@ class qplotTestConan(ConanFile):
         # Test
         if not tools.cross_building(self.settings):
             os.chdir("bin")
-            self.run("objdump -s -j .note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6Core.so.6.2.4")
-            # self.run("ldd `which qmake6`")
-            # self.run("strip -v --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6*.so.?.?.?")
-            # self.run("ldd `which qmake6`")
             self.run(".%sexample -platform offscreen" % os.sep)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -20,5 +20,5 @@ class qplotTestConan(ConanFile):
     def test(self):
         if not tools.cross_building(self.settings):
             os.chdir("bin")
-            self.run("qmake6 -v")
+            self.run("ldd `which qmake6`")
             self.run(".%sexample -platform offscreen" % os.sep, ignore_errors=True)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -18,7 +18,6 @@ class qplotTestConan(ConanFile):
         self.copy("*.a", dst="bin", src='lib')
 
     def test(self):
-        # Test
         if not tools.cross_building(self.settings):
             os.chdir("bin")
             self.run(".%sexample -platform offscreen" % os.sep)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -21,5 +21,4 @@ class qplotTestConan(ConanFile):
         # Test
         if not tools.cross_building(self.settings):
             os.chdir("bin")
-            # Hope this works now
             self.run(".%sexample -platform offscreen" % os.sep)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -20,7 +20,7 @@ class qplotTestConan(ConanFile):
     def test(self):
         if not tools.cross_building(self.settings):
             os.chdir("bin")
-            # self.run("ldd `which qmake6`")
+            self.run("ldd `which qmake6`")
             # self.run("strip -v --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6*.so.?.?.?")
             # self.run("ldd `which qmake6`")
             self.run(".%sexample -platform offscreen" % os.sep)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -21,4 +21,5 @@ class qplotTestConan(ConanFile):
         # Test
         if not tools.cross_building(self.settings):
             os.chdir("bin")
+            # Hope this works now
             self.run(".%sexample -platform offscreen" % os.sep)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -20,7 +20,7 @@ class qplotTestConan(ConanFile):
     def test(self):
         if not tools.cross_building(self.settings):
             os.chdir("bin")
-            self.run("ldd `which qmake6`")
-            self.run("strip -v --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6*.so.?.?.?")
-            self.run("ldd `which qmake6`")
+            # self.run("ldd `which qmake6`")
+            # self.run("strip -v --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6*.so.?.?.?")
+            # self.run("ldd `which qmake6`")
             self.run(".%sexample -platform offscreen" % os.sep)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -21,6 +21,6 @@ class qplotTestConan(ConanFile):
         if not tools.cross_building(self.settings):
             os.chdir("bin")
             self.run("ldd `which qmake6`")
-            self.run("strip -v --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6*.so.?.?.?")
-            self.run("ldd `which qmake6`")
+            # self.run("strip -v --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6*.so.?.?.?")
+            # self.run("ldd `which qmake6`")
             self.run(".%sexample -platform offscreen" % os.sep)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -20,7 +20,7 @@ class qplotTestConan(ConanFile):
     def test(self):
         if not tools.cross_building(self.settings):
             os.chdir("bin")
-            self.run("objdump -s -j .note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6Core.so.6.2.4")
+#            self.run("objdump -s -j .note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6Core.so.6.2.4")
             self.run("ldd `which qmake6`")
             self.run("strip -v --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6*.so.?.?.?")
             self.run("ldd `which qmake6`")

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -21,8 +21,8 @@ class qplotTestConan(ConanFile):
         # Test
         if not tools.cross_building(self.settings):
             os.chdir("bin")
-#            self.run("objdump -s -j .note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6Core.so.6.2.4")
-            self.run("ldd `which qmake6`")
-            self.run("strip -v --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6*.so.?.?.?")
-            self.run("ldd `which qmake6`")
+            self.run("objdump -s -j .note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6Core.so.6.2.4")
+            # self.run("ldd `which qmake6`")
+            # self.run("strip -v --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6*.so.?.?.?")
+            # self.run("ldd `which qmake6`")
             self.run(".%sexample -platform offscreen" % os.sep)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -20,5 +20,6 @@ class qplotTestConan(ConanFile):
     def test(self):
         if not tools.cross_building(self.settings):
             os.chdir("bin")
+            self.run("strip -v --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6*.so.?.?.?")
             self.run("ldd `which qmake6`")
             self.run(".%sexample -platform offscreen" % os.sep, ignore_errors=True)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -20,4 +20,5 @@ class qplotTestConan(ConanFile):
     def test(self):
         if not tools.cross_building(self.settings):
             os.chdir("bin")
+            self.run("uname -a")
             self.run(".%sexample -platform offscreen" % os.sep, ignore_errors=True)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -20,5 +20,5 @@ class qplotTestConan(ConanFile):
     def test(self):
         if not tools.cross_building(self.settings):
             os.chdir("bin")
-            self.run("uname -a")
+            self.run("qmake -v")
             self.run(".%sexample -platform offscreen" % os.sep, ignore_errors=True)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -21,7 +21,7 @@ class qplotTestConan(ConanFile):
         if not tools.cross_building(self.settings):
             os.chdir("bin")
             self.run("objdump -s -j .note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6Core.so.6.2.4")
-            # self.run("ldd `which qmake6`")
-            # self.run("strip -v --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6*.so.?.?.?")
-            # self.run("ldd `which qmake6`")
+            self.run("ldd `which qmake6`")
+            self.run("strip -v --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6*.so.?.?.?")
+            self.run("ldd `which qmake6`")
             self.run(".%sexample -platform offscreen" % os.sep)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -22,5 +22,6 @@ class qplotTestConan(ConanFile):
         if not tools.cross_building(self.settings):
             os.chdir("bin")
 #            self.run("objdump -s -j .note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6Core.so.6.2.4")
+            self.run("ls /usr/lib/x86_64-linux-gnu/libQt6Core.so.6.2.4")
             self.run("ldd `which qmake6`")
             self.run(".%sexample -platform offscreen" % os.sep)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -20,7 +20,6 @@ class qplotTestConan(ConanFile):
     def test(self):
         if not tools.cross_building(self.settings):
             os.chdir("bin")
-            self.run("objdump -s -j .note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6Core.so.6.2.4")
             self.run("ldd `which qmake6`")
             self.run("strip -v --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6*.so.?.?.?")
             self.run("ldd `which qmake6`")

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -20,5 +20,4 @@ class qplotTestConan(ConanFile):
     def test(self):
         if not tools.cross_building(self.settings):
             os.chdir("bin")
-            self.run("ldd /usr/lib/x86_64-linux-gnu/libQt6Gui.so")
-            self.run(".%sexample -platform offscreen" % os.sep)
+            self.run(".%sexample -platform offscreen" % os.sep, ignore_errors=True)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -20,7 +20,7 @@ class qplotTestConan(ConanFile):
     def test(self):
         if not tools.cross_building(self.settings):
             os.chdir("bin")
-#            self.run("objdump -s -j .note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6Core.so.6.2.4")
+            self.run("objdump -s -j .note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6Core.so.6.2.4")
             self.run("ldd `which qmake6`")
             self.run("strip -v --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6*.so.?.?.?")
             self.run("ldd `which qmake6`")

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -20,6 +20,7 @@ class qplotTestConan(ConanFile):
     def test(self):
         if not tools.cross_building(self.settings):
             os.chdir("bin")
+            self.run("ldd `which qmake6`")
             self.run("strip -v --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6*.so.?.?.?")
             self.run("ldd `which qmake6`")
-            self.run(".%sexample -platform offscreen" % os.sep, ignore_errors=True)
+            self.run(".%sexample -platform offscreen" % os.sep)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -20,7 +20,7 @@ class qplotTestConan(ConanFile):
     def test(self):
         if not tools.cross_building(self.settings):
             os.chdir("bin")
-            self.run("ls -l /usr/lib/x86_64-linux-gnu/libQt6Core.so.6.2.4")
+            self.run("objdump -s -j .note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6Core.so.6.2.4")
             # self.run("ldd `which qmake6`")
             # self.run("strip -v --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6*.so.?.?.?")
             # self.run("ldd `which qmake6`")

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -20,7 +20,7 @@ class qplotTestConan(ConanFile):
     def test(self):
         if not tools.cross_building(self.settings):
             os.chdir("bin")
-            self.run("objdump -s -j .note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6Core.so.6.2.4")
+            self.run("ls -l /usr/lib/x86_64-linux-gnu/libQt6Core.so.6.2.4")
             # self.run("ldd `which qmake6`")
             # self.run("strip -v --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6*.so.?.?.?")
             # self.run("ldd `which qmake6`")

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -20,7 +20,8 @@ class qplotTestConan(ConanFile):
     def test(self):
         if not tools.cross_building(self.settings):
             os.chdir("bin")
-            self.run("ldd `which qmake6`")
-            self.run("strip -v --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6*.so.?.?.?")
-            self.run("ldd `which qmake6`")
+            self.run("objdump -s -j .note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6Core.so.6.2.4")
+            # self.run("ldd `which qmake6`")
+            # self.run("strip -v --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt6*.so.?.?.?")
+            # self.run("ldd `which qmake6`")
             self.run(".%sexample -platform offscreen" % os.sep)


### PR DESCRIPTION
https://jira.ess.eu/browse/ECDC-4544

After the ticket [ECDC-4485](https://jira.ess.eu/browse/ECDC-4544), this is the next step in the Qt6 update sequence: Updating the conan-qplot package to Qt6